### PR TITLE
Test Enhancement for versions and some stuffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ git:
 sudo: false
 
 php:
-- 5.6
-- 7.0
 - 7.1
 - 7.2
+- 7.3
+- 7.4
 - hhvm
 - nightly
 

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.1",
         "ext-json": "*",
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.11 || ^6.4 || ^7.0"
+        "phpunit/phpunit": "^7.5"
     },
     "autoload": {
         "files": [

--- a/tests/Factory/ISO3166CountryFactoryAlpha2Test.php
+++ b/tests/Factory/ISO3166CountryFactoryAlpha2Test.php
@@ -82,7 +82,7 @@ class ISO3166CountryFactoryAlpha2Test extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Factory/ISO3166CountryFactoryAlpha3Test.php
+++ b/tests/Factory/ISO3166CountryFactoryAlpha3Test.php
@@ -82,7 +82,7 @@ class ISO3166CountryFactoryAlpha3Test extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Factory/ISO3166CountryFactoryNumericTest.php
+++ b/tests/Factory/ISO3166CountryFactoryNumericTest.php
@@ -70,7 +70,7 @@ class ISO3166CountryFactoryNumericTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/GetNumericCountryCodesTest.php
+++ b/tests/GetNumericCountryCodesTest.php
@@ -18,9 +18,9 @@ class GetNumericCountryCodesTest extends TestCase
         self::assertCount(ISO_3166_1_COUNTRIES_NUMBER, $countries, 'Currently 249 countries in ISO 3166-1');
 
         foreach ($countries as $code => $name) {
-            self::assertEquals(ISO_3166_1_NUMERIC_CODE_LENGTH, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 3 characters', $code));
+            self::assertSame(ISO_3166_1_NUMERIC_CODE_LENGTH, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 3 characters', $code));
             self::assertNotEmpty($name, 'Country name should not be blank.');
-            self::assertTrue(is_numeric($code));
+            self::assertIsNumeric($code);
         }
     }
 }

--- a/tests/GetThreeCharacterCountriesTest.php
+++ b/tests/GetThreeCharacterCountriesTest.php
@@ -18,7 +18,7 @@ class GetThreeCharacterCountriesTest extends TestCase
         self::assertCount(ISO_3166_1_COUNTRIES_NUMBER, $countries, 'Currently 249 countries in ISO 3166-1');
 
         foreach ($countries as $code => $name) {
-            self::assertEquals(3, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 3 characters', $code));
+            self::assertSame(3, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 3 characters', $code));
             self::assertNotEmpty($name, 'Country name should not be blank.');
         }
     }

--- a/tests/GetTwoCharacterCountriesTest.php
+++ b/tests/GetTwoCharacterCountriesTest.php
@@ -18,7 +18,7 @@ class GetTwoCharacterCountriesTest extends TestCase
         self::assertCount(ISO_3166_1_COUNTRIES_NUMBER, $countries, 'Currently 249 countries in ISO 3166-1');
 
         foreach ($countries as $code => $name) {
-            self::assertEquals(ISO_3166_1_ALPHA_2_CODE_LENGTH, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 2 characters', $code));
+            self::assertSame(ISO_3166_1_ALPHA_2_CODE_LENGTH, mb_strlen($code), sprintf('Invalid code "%s". Country code should have exactly 2 characters', $code));
             self::assertNotEmpty($name, 'Country name should not be blank.');
         }
     }

--- a/tests/ValueObject/CountryTest.php
+++ b/tests/ValueObject/CountryTest.php
@@ -22,11 +22,11 @@ class CountryTest extends TestCase
         $name = 'Ukraine';
         $country = new Country($code, $name);
 
-        self::assertEquals($code, $country->getCode(), '');
-        self::assertEquals($name, $country->getName(), '');
+        self::assertSame($code, $country->getCode(), '');
+        self::assertSame($name, $country->getName(), '');
 
-        self::assertEquals('804 Ukraine', (string) $country);
-        self::assertEquals('{"code":"804","name":"Ukraine"}', json_encode($country));
+        self::assertSame('804 Ukraine', (string) $country);
+        self::assertSame('{"code":"804","name":"Ukraine"}', json_encode($country));
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Drop `php-5.6` and `php-7.0` version and let this package require `php-7.1` version at least.
- To require `php-7.1` version at least, it should be good to let package require `phpunit/phpunit` `^7.5` version at least.
- Using the `assertSame` to replace `assertEquals` and it can make equals assertion strict.